### PR TITLE
Use github as source for grammar install files

### DIFF
--- a/lua/tree-sitter-jinja2.lua
+++ b/lua/tree-sitter-jinja2.lua
@@ -2,7 +2,7 @@ local M = {}
 
 
 local install_info = {
-  url = "~/code/tree-sitter-jinja2",
+  url = "https://github.com/geigerzaehler/tree-sitter-jinja2",
   files = { "src/parser.c" },
   branch = "main",
 }


### PR DESCRIPTION
Currently the install URL is set to a local path. This PR changes it to use this Github repo.